### PR TITLE
feat: Add separateScopes flag on DynamicClusterRole

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ spec:
     annotations: {}
     labels: {}
 
+    # This flag create two separated ClusterRoles: 
+    # one for cluster-wide resources and another for namespace-scoped resources
+    separateScopes: false
+
   # This is where the allowed policies are expressed
   # Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
   allow:

--- a/api/v1alpha1/dynamicclusterrole_types.go
+++ b/api/v1alpha1/dynamicclusterrole_types.go
@@ -23,9 +23,12 @@ import (
 
 // TargetT defines the spec of the target section of a DynamicClusterRole
 type TargetT struct {
-	Name        string            `json:"name"`
+	Name string `json:"name"`
+
 	Annotations map[string]string `json:"annotations,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
+
+	SeparateScopes bool `json:"separateScopes,omitempty"`
 }
 
 // DynamicClusterRoleSpec defines the desired state of DynamicClusterRole

--- a/config/crd/bases/kuberbac.prosimcorp.com_dynamicclusterroles.yaml
+++ b/config/crd/bases/kuberbac.prosimcorp.com_dynamicclusterroles.yaml
@@ -159,6 +159,8 @@ spec:
                     type: object
                   name:
                     type: string
+                  separateScopes:
+                    type: boolean
                 required:
                 - name
                 type: object

--- a/config/samples/kuberbac_v1alpha1_dynamicclusterrole.yaml
+++ b/config/samples/kuberbac_v1alpha1_dynamicclusterrole.yaml
@@ -13,6 +13,10 @@ spec:
     annotations: {}
     labels: {}
 
+    # This flag create two separated ClusterRoles: 
+    # one for cluster-wide resources and another for namespace-scoped resources
+    separateScopes: false
+
   # This is where the allowed policies are expressed
   # Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
   allow:

--- a/docs/prototype/dynamicClusterRole.yaml
+++ b/docs/prototype/dynamicClusterRole.yaml
@@ -13,6 +13,10 @@ spec:
     annotations: {}
     labels: {}
 
+    # This flag create two separated ClusterRoles: 
+    # one for cluster-wide resources and another for namespace-scoped resources
+    separateScopes: false
+
   # This is where the allowed policies are expressed
   # Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
   allow:

--- a/internal/controller/dynamicclusterrole_sync.go
+++ b/internal/controller/dynamicclusterrole_sync.go
@@ -608,10 +608,21 @@ func (r *DynamicClusterRoleReconciler) SyncTarget(ctx context.Context, resource 
 	// We assume always only one ClusterRole, but this will be transformed into two when asked to separate scopes.
 	clusterRoles := []rbacv1.ClusterRole{}
 
+	referenceAnnotations := map[string]string{
+		"kuberbac.prosimcorp.com/owner-apiversion": resource.APIVersion,
+		"kuberbac.prosimcorp.com/owner-kind":       resource.Kind,
+		"kuberbac.prosimcorp.com/owner-name":       resource.ObjectMeta.Name,
+		"kuberbac.prosimcorp.com/owner-namespace":  resource.ObjectMeta.Namespace,
+	}
+
+	if len(resource.Spec.Target.Annotations) == 0 {
+		resource.Spec.Target.Annotations = map[string]string{}
+	}
+
 	clusterRoleResource := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        resource.Spec.Target.Name,
-			Annotations: resource.Spec.Target.Annotations,
+			Annotations: referenceAnnotations,
 			Labels:      resource.Spec.Target.Labels,
 		},
 		Rules: maps.Values(result),

--- a/internal/controller/dynamicclusterrole_sync.go
+++ b/internal/controller/dynamicclusterrole_sync.go
@@ -27,6 +27,10 @@ type GVKR struct {
 	GVK         schema.GroupVersionKind
 	Resource    string
 	Subresource string
+
+	//
+	Namespaced  bool
+	UsableVerbs []string // Intended for future use polishing resulting verbs
 }
 
 // PolicyRulesProcessorT represents the things done
@@ -102,6 +106,8 @@ func (p *PolicyRulesProcessorT) SetResourcesByGroup() (err error) {
 					Version: version,
 					Kind:    apiResource.Kind,
 				},
+				Namespaced:  apiResource.Namespaced,
+				UsableVerbs: apiResource.Verbs,
 			})
 		}
 	}
@@ -520,6 +526,39 @@ func (p *PolicyRulesProcessorT) EvaluatePolicyRules(allowMap, denyMap map[string
 	return result, err
 }
 
+// SplitPolicyRules separates PolicyRules into two lists: clusterScopedRules and namespaceScopedRules
+func (p *PolicyRulesProcessorT) SplitPolicyRules(policyRules []rbacv1.PolicyRule) (clusterScopedRules, namespaceScopedRules []rbacv1.PolicyRule) {
+
+	for _, policyRule := range policyRules {
+
+		// Look for current PolicyRule in the resourcesByGroup map
+		for _, resource := range p.ResourcesByGroup[policyRule.APIGroups[0]] {
+
+			//
+			resourceName := resource.Resource
+			if resource.Subresource != "" {
+				resourceName += "/" + resource.Subresource
+			}
+
+			// Ignore when it is not the correct resource
+			if policyRule.Resources[0] != resourceName {
+				continue
+			}
+
+			// Add to the corresponding list
+			if resource.Namespaced {
+				namespaceScopedRules = append(namespaceScopedRules, policyRule)
+			} else {
+				clusterScopedRules = append(clusterScopedRules, policyRule)
+			}
+
+			break
+		}
+	}
+
+	return clusterScopedRules, namespaceScopedRules
+}
+
 // GetSyncTime return the spec.synchronization.time as duration, or default time on failures
 func (r *DynamicClusterRoleReconciler) GetSyncTime(resource *kuberbacv1alpha1.DynamicClusterRole) (syncTime time.Duration, err error) {
 
@@ -540,15 +579,16 @@ func (r *DynamicClusterRoleReconciler) SyncTarget(ctx context.Context, resource 
 		return fmt.Errorf("error generating PolicyRulesProcessor: %s", err.Error())
 	}
 
-	// Convert '*'
+	// Transform '*' symbols with actual things
 	expandedAllowList := policyRulesProcessor.ExpandPolicyRules(resource.Spec.Allow)
 	expandedDenyList := policyRulesProcessor.ExpandPolicyRules(resource.Spec.Deny)
 
-	//
+	// Stretch policy rules to a single resource per item
 	stretchAllowList := policyRulesProcessor.StretchPolicyRules(expandedAllowList)
 	stretchDenyList := policyRulesProcessor.StretchPolicyRules(expandedDenyList)
 
-	//
+	// Craft a map with stretched policy rules. Its keys are created as unique identifiers.
+	// This is done to increase performance when evaluating the rules.
 	allowMap := policyRulesProcessor.GetMapFromStretchedPolicyRules(stretchAllowList)
 	denyMap := policyRulesProcessor.GetMapFromStretchedPolicyRules(stretchDenyList)
 
@@ -564,6 +604,10 @@ func (r *DynamicClusterRoleReconciler) SyncTarget(ctx context.Context, resource 
 		return fmt.Errorf("error evaluating allow and deny maps: %s", err.Error())
 	}
 
+	// Create a list of ClusterRoles to be created.
+	// We assume always only one ClusterRole, but this will be transformed into two when asked to separate scopes.
+	clusterRoles := []rbacv1.ClusterRole{}
+
 	clusterRoleResource := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        resource.Spec.Target.Name,
@@ -573,10 +617,29 @@ func (r *DynamicClusterRoleReconciler) SyncTarget(ctx context.Context, resource 
 		Rules: maps.Values(result),
 		// TODO: Implement AggregationRules later
 	}
+	clusterRoles = append(clusterRoles, clusterRoleResource)
 
-	err = r.Client.Update(ctx, &clusterRoleResource)
-	if err != nil {
-		err = fmt.Errorf("error updating ClusterRole: %s", err.Error())
+	//
+	if resource.Spec.Target.SeparateScopes {
+		clusterScopedRules, namespaceScopedRules := policyRulesProcessor.SplitPolicyRules(maps.Values(result))
+
+		// Assume first ClusterRole as clusterScoped
+		clusterRoles[0].Rules = clusterScopedRules
+		clusterRoles[0].Name = resource.Spec.Target.Name + "-cluster"
+
+		// Create a new ClusterRole for namespaceScoped
+		clusterRoles = append(clusterRoles, *clusterRoleResource.DeepCopy())
+		clusterRoles[1].Rules = namespaceScopedRules
+		clusterRoles[1].Name = resource.Spec.Target.Name + "-namespace"
+	}
+
+	//
+	for _, clusterRole := range clusterRoles {
+		err = r.Client.Update(ctx, &clusterRole)
+		if err != nil {
+			err = fmt.Errorf("error updating ClusterRole: %s", err.Error())
+			break
+		}
 	}
 
 	return err


### PR DESCRIPTION
**Description:**

In some cases, when working with DynamicClusterRole, it can be interesting to separate the resulting ClusterRole in two: one for cluster-wide resources and other for namespaced-scope resources. This way we can link the first with a ClusterRoleBinding and the second with RoleBindings produced by DynamicRoleBinding

This PR does exactly that